### PR TITLE
[@types/auth0] audience property missing from PasswordGrantOptions

### DIFF
--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -611,6 +611,7 @@ export interface PasswordGrantOptions {
   password: string;
   realm?: string;
   scope?: string;
+  audience?: string;
 }
 
 export interface AuthorizationCodeGrantOptions {


### PR DESCRIPTION
adding optional audience property to PasswordGrantOptions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test YOUR_PACKAGE_NAME`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://auth0.com/docs/flows/call-your-api-using-resource-owner-password-flow#request-tokens
https://github.com/auth0/node-auth0/blob/master/src/auth/OAuthAuthenticator.js#L152



