### PR TITLE
Revert "[@types/auth0] audience property missing from PasswordGrantOptions"

### DIFF
--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -611,7 +611,6 @@ export interface PasswordGrantOptions {
   password: string;
   realm?: string;
   scope?: string;
-  audience?: string;
 }
 
 export interface AuthorizationCodeGrantOptions {


### PR DESCRIPTION
Reverts RobRolls/DefinitelyTyped#1